### PR TITLE
Implementação de serviço mock para validação de CPF com Profiles

### DIFF
--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/controller/ReceitaController.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/controller/ReceitaController.java
@@ -10,20 +10,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.cdb.bancodigitaljpa.response.CpfValidationResponse;
-import br.com.cdb.bancodigitaljpa.service.ReceitaCpfService;
+import br.com.cdb.bancodigitaljpa.service.ReceitaService;
 
 @RestController
 @RequestMapping("/receita-federal")
-public class ReceitaCpfController {
+public class ReceitaController {
 	
 	@Autowired
-	private ReceitaCpfService receitaCpfService;
+	private ReceitaService receitaService;
 	
 	// só admin pode verificar cpfs
 	@PreAuthorize("hasRole('ADMIN')")
 	@GetMapping("/consultar-cpf/{cpf}")
 	public ResponseEntity<CpfValidationResponse> consultarCpf(@PathVariable String cpf) {
-		CpfValidationResponse response = receitaCpfService.consultarCpf(cpf);
+		CpfValidationResponse response = receitaService.consultarCpf(cpf);
 		
 		if (response == null || Boolean.FALSE.equals(response.isSuccess())) {
 			return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(response);

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/controller/SeguroController.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/controller/SeguroController.java
@@ -106,6 +106,16 @@ public class SeguroController {
 		return ResponseEntity.ok(seguro);	
 	}
 	
+	// para usuário logado ver informações de seus cartoes (cliente)
+	@PreAuthorize("hasRole('CLIENTE')")
+	@GetMapping("/meus-seguros")
+	public ResponseEntity<List<SeguroResponse>> buscarSegurosDoUsuario (
+			Authentication authentication) {
+		Usuario usuarioLogado = (Usuario) authentication.getPrincipal();
+		List<SeguroResponse> seguros = seguroService.listarPorUsuario(usuarioLogado);
+		return ResponseEntity.ok(seguros);
+	}
+	
 	// cancelar apólice
 	// admin tem acesso ao id, cliente só pode ver se for dele
 	@PutMapping("/{id_seguro}/cancelar")

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ClienteService.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ClienteService.java
@@ -62,7 +62,7 @@ public class ClienteService {
 	private PoliticaDeTaxasRepository politicaDeTaxaRepository;
 	
 	@Autowired
-	private ReceitaCpfService receitaCpfService;
+	private ReceitaService receitaService;
 	
 	@Autowired
 	private SecurityService securityService;
@@ -73,7 +73,7 @@ public class ClienteService {
 		Cliente cliente = dto.transformaParaObjeto();
 		cliente.setUsuario(usuario);
 		
-		if(!receitaCpfService.isCpfValidoEAtivo(cliente.getCpf())) throw new InvalidInputParameterException("CPF inválido ou inativo na Receita Federal");
+		if(!receitaService.isCpfValidoEAtivo(cliente.getCpf())) throw new InvalidInputParameterException("CPF inválido ou inativo na Receita Federal");
 		
 		validarCpfUnico(cliente.getCpf());
 		validarMaiorIdade(cliente);

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaMockService.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaMockService.java
@@ -1,0 +1,28 @@
+package br.com.cdb.bancodigitaljpa.service;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import br.com.cdb.bancodigitaljpa.response.CpfValidationResponse;
+
+@Service
+@Profile("dev")
+public class ReceitaMockService implements ReceitaService {
+
+	@Override
+	public boolean isCpfValidoEAtivo(String cpf) {
+		return true; // Sempre retorna como válido e ativo 
+	}
+	
+	@Override
+	public CpfValidationResponse consultarCpf(String cpf) {
+		CpfValidationResponse response = new CpfValidationResponse();
+		response.setSuccess(true);
+		response.setCpf(cpf);
+		response.setValid(true);
+		response.setStatus("ATIVO");
+		response.setMessage("CPF válido e ativo");
+		return response; // Sempre retorna como válido e ativo 
+	}
+
+}

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaRealService.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaRealService.java
@@ -3,6 +3,7 @@ package br.com.cdb.bancodigitaljpa.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -15,9 +16,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import br.com.cdb.bancodigitaljpa.response.CpfValidationResponse;
 
 @Service 
-public class ReceitaCpfService {
+@Profile("prod") // roda apenas com a API externa de simulação da Receita Federal
+public class ReceitaRealService implements ReceitaService{
 	
-	private static final Logger log = LoggerFactory.getLogger(ReceitaCpfService.class);
+	private static final Logger log = LoggerFactory.getLogger(ReceitaRealService.class);
 
 	@Autowired
 	private RestTemplate restTemplate;
@@ -47,6 +49,7 @@ public class ReceitaCpfService {
 
 	}
 	
+	@Override
 	public boolean isCpfValidoEAtivo(String cpf) {
 		CpfValidationResponse response = consultarCpf(cpf);
 		return response.isValid().equals(Boolean.TRUE) && response.getStatus().equals("ATIVO");

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaService.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/ReceitaService.java
@@ -1,0 +1,9 @@
+package br.com.cdb.bancodigitaljpa.service;
+
+import br.com.cdb.bancodigitaljpa.response.CpfValidationResponse;
+
+public interface ReceitaService {
+	boolean isCpfValidoEAtivo(String cpf);
+	CpfValidationResponse consultarCpf(String cpf);
+
+}

--- a/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/SeguroService.java
+++ b/bancodigitaljpa/src/main/java/br/com/cdb/bancodigitaljpa/service/SeguroService.java
@@ -95,6 +95,12 @@ public class SeguroService {
 		securityService.validateAccess(usuarioLogado, seguro.getCartaoCredito().getConta().getCliente());
 		return SeguroResponse.toSeguroResponse(seguro);
 	}
+	
+	// get seguro por usuario
+	public List<SeguroResponse> listarPorUsuario(Usuario usuario) {
+		List<SeguroBase> seguros = seguroRepository.findByCartaoCreditoContaClienteUsuario(usuario);
+		return seguros.stream().map(this::toResponse).toList();
+	}
 
 	// cancelar apolice seguro
 	@Transactional

--- a/bancodigitaljpa/src/main/resources/application.properties
+++ b/bancodigitaljpa/src/main/resources/application.properties
@@ -24,3 +24,5 @@ spring.jpa.properties.hibernate.type=trace
 #
 jwt.secret=minha-chave-super-secreta-minha-chave-super-secreta
 logging.level.org.springframework.security=DEBUG
+
+spring.profiles.active=dev


### PR DESCRIPTION
## 📄 Descrição

Este Pull Request implementa uma versão mock da API de validação de CPF da Receita Federal, permitindo que o projeto funcione localmente sem depender da API externa.

## ✅ Alterações realizadas

- Criação da interface `ReceitaService` para abstração da validação de CPF
- Implementação real (`ReceitaRealService`) ativada com o profile `prod`
- Implementação mock (`ReceitaMockService`) ativada com o profile `dev`
- Alteração do `application.properties` para setar `spring.profiles.active=dev` por padrão
- Atualização do método `cadastrarCliente()` no `ClienteService` para utilizar a interface abstrata

## 🧪 Como testar

1. Rodar a aplicação com o Spring Profile `dev` (padrão no `application.properties`)
2. Realizar uma requisição de cadastro de cliente com qualquer CPF
3. A validação do CPF será automaticamente aceita via mock (retorna `true`)
4. Trocar o profile para `prod` para usar a validação real (se desejar)

## 🧠 Motivação

Facilitar o uso e testes da aplicação por outras pessoas, mesmo sem a necessidade de subir a API externa da Receita Federal.

## 📌 Observações

- A versão mock da Receita **aceita qualquer CPF** como válido.
- A separação por perfil permite alternar facilmente entre ambientes real e de testes.
- Isso melhora a experiência de quem clonar o projeto e quer rodar localmente.

